### PR TITLE
Added El Capitan Mac binary identifier to selection statement

### DIFF
--- a/R/run_glm.R
+++ b/R/run_glm.R
@@ -35,7 +35,7 @@ run_glm <- function(sim_folder = '.', verbose=TRUE, args=character()){
 		
 		return(run_glmWin(sim_folder, verbose, args))
 		
-	}else if(.Platform$pkgType == "mac.binary" || 
+	}else if(.Platform$pkgType == "mac.binary" || .Platform$pkgType == "mac.binary.el-capitan" ||
 					 	.Platform$pkgType == "mac.binary.mavericks"){
     maj_v_number <- as.numeric(strsplit(
                       Sys.info()["release"][[1]],'.', fixed = TRUE)[[1]][1])


### PR DESCRIPTION
As of R version 3.4.2, the platform reported by R for machines running El Capitan or Sierra is "mac.binary.el-capitan" rather than the former "mac.binary" for previous (post-mavericks) versions. This resolves the issue of GLMr failing to function normally with SIP disabled in R 3.4.2. 